### PR TITLE
chore: drop spotlight-specific env from node-ci caller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,3 @@ jobs:
       node-version: '20'
       coverage: true
       audit: true
-      test-token: test-token
-      test-github-user: mock-user

--- a/tests/setup.mjs
+++ b/tests/setup.mjs
@@ -1,8 +1,12 @@
 import { vi } from 'vitest';
 
-// Mock environment variables
-process.env.GITHUB_TOKEN = 'test-token';
-process.env.GITHUB_REPOSITORY = 'test-org/test-repo';
+// Mock environment variables for unit tests (keep CI reusable generic)
+process.env.GITHUB_TOKEN = process.env.GITHUB_TOKEN || 'test-token';
+process.env.GH_SPOTLIGHT_TOKEN =
+  process.env.GH_SPOTLIGHT_TOKEN || 'test-token';
+process.env.GITHUB_USER = process.env.GITHUB_USER || 'mock-user';
+process.env.GITHUB_REPOSITORY =
+  process.env.GITHUB_REPOSITORY || 'test-org/test-repo';
 
 // Dummy repository data
 const dummyRepos = [


### PR DESCRIPTION
## Summary
- Call generic `node-ci-workflow` without `test-token` / `test-github-user`
- Move `GH_SPOTLIGHT_TOKEN` / `GITHUB_USER` mocks into `tests/setup.mjs`

Depends on [actionsforge/actions#123](https://github.com/actionsforge/actions/pull/123) landing on `main` first (`uses: ...@main`).

## Test plan
- [ ] Local `npm test` green
- [ ] CI green after actions#123 merge